### PR TITLE
構文木デザイン変更+アイコン表示&ログアウト機能修正#24

### DIFF
--- a/frontend/src/components/ASTTree.tsx
+++ b/frontend/src/components/ASTTree.tsx
@@ -19,6 +19,37 @@ const transformASTToTree = (node: ASTNode): TreeNode => {
     };
 };
 
+interface CustomNodeElementProps {
+    nodeDatum: TreeNode;
+}
+
+//文字数が10文字以上かどうかで変更予定
+const CustomNodeElement: React.FC<CustomNodeElementProps> = ({ nodeDatum }) => {
+    return (
+      <g>
+        <rect
+          x="-50"
+          y="-45"
+          rx="5"
+          ry="5"
+          style={{
+            width: "100",
+            height: '90',
+            fill: 'turquoise',
+            stroke: 'salmon',
+            strokeWidth: '3'
+          }}
+        />
+        <foreignObject x="-50" y="-45" width="100px" height="90px">
+        <div xmlns="http://www.w3.org/1999/xhtml"
+        className="w-[100px] h-[90px] flex items-center justify-center break-words text-center"
+        style={{ wordBreak: 'break-word' }}
+        >{nodeDatum.name}</div>
+      </foreignObject>
+      </g>
+    )
+  }
+
 const ASTTree: React.FC<ASTTreeProps> = ({node}) => {
     const [translate, setTranslate] = useState({x: 0, y: 0});
     const treeContainer = useRef<HTMLDivElement>(null);
@@ -27,8 +58,8 @@ const ASTTree: React.FC<ASTTreeProps> = ({node}) => {
         if (treeContainer.current) {
             const dimensions = treeContainer.current.getBoundingClientRect();
             setTranslate({
-                x: dimensions.width,
-                y: dimensions.height,
+                x: dimensions.width/2,
+                y: dimensions.height/2,
             });
         }
     }, []);
@@ -39,9 +70,12 @@ const ASTTree: React.FC<ASTTreeProps> = ({node}) => {
         <div id="treeWrapper" style={{width: "100%", height: "500px", border: "1px solid #ccc", backgroundColor: "#bbb"}} ref={treeContainer}>
             <Tree
                 data={treeData}
+                renderCustomNodeElement={({ nodeDatum }) =>
+                    <CustomNodeElement nodeDatum={nodeDatum} />
+                }
                 translate={translate}
                 orientation="vertical"
-                pathFunc="elbow"
+                pathFunc="step"
             />
         </div>
     );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,11 +1,18 @@
-import { useContext } from "react";
+import { useContext,useState,useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { logout } from "../services/api";
 import { AuthContext } from "../context/AuthContext";
 import "../index.css";
+import  LogoutModal  from "./LogoutModal";
 
 function Header() {
     const { user, setUser } = useContext(AuthContext);
+    const [showModal, setShowModal] = useState(false);
+    const iconButtonRef = useRef<HTMLButtonElement>(null);
+
+    const ShowModal = () => {
+        setShowModal(true);
+    };
 
     const handleLogout = async () => {
         const success = await logout();
@@ -35,13 +42,23 @@ function Header() {
                     </Link>
                     {user ? (
                         <>
-                            <div className="text-gray-700">{user.name}</div>
                             <button
-                                onClick={handleLogout}
-                                className="text-gray-700 hover:text-red-500 transition-colors"
+                                 onClick={ShowModal}
+                                 className="relative m-0 cursor-pointer"
+                                 ref={iconButtonRef}
                             >
-                                ログアウト
+                            <img
+                                src={user.picture}
+                                alt={'${user.name}'}
+                                className="w-8 h-8 rounded-full hover:brightness-75 transition duration-200"
+                            />
                             </button>
+                            <LogoutModal 
+                                showFlag={showModal}
+                                setShowModal={setShowModal}
+                                handleLogout={handleLogout}
+                                targetRef={iconButtonRef}
+                            />
                         </>
                     ) : (
                         <Link to="/login" className="text-gray-700 hover:text-blue-500 transition-colors">
@@ -53,5 +70,10 @@ function Header() {
         </header>
     );
 }
-
+/*<button
+    onClick={handleLogout}
+    className="text-gray-700 hover:text-red-500 transition-colors"
+>
+    ログアウト
+</button>*/
 export default Header;

--- a/frontend/src/components/LogoutModal.tsx
+++ b/frontend/src/components/LogoutModal.tsx
@@ -1,0 +1,49 @@
+import { useRef, useEffect } from "react";
+
+const LogoutModal = (props: any) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+
+    const updateModalPosition = () => {
+        if (modalRef.current && props.targetRef.current) {
+            const iconRect = props.targetRef.current.getBoundingClientRect();
+            modalRef.current.style.top = `${iconRect.bottom}px`;
+            modalRef.current.style.left = `${iconRect.left-45}px`;
+        }
+    };
+
+    useEffect(() => {
+        if (props.showFlag) {
+            updateModalPosition();
+            window.addEventListener('resize', updateModalPosition);
+            window.addEventListener('scroll', updateModalPosition);
+        }
+
+        return () => {
+            updateModalPosition();
+            window.removeEventListener('resize', updateModalPosition);
+            window.removeEventListener('scroll', updateModalPosition);
+        };
+    }, [props.showFlag]);
+
+    return (
+        <>
+            {props.showFlag ? (
+                <div className="fixed inset-0 flex justify-center items-start z-50">
+                    <div className="bg-white p-5 rounded shadow-lg fixed z-60" ref={modalRef}>
+                        <button
+                            onClick={props.handleLogout}
+                            className="text-gray-700 hover:text-red-500 transition-colors cursor-pointer mb-2"
+                        >ログアウト</button>
+                        <br/>
+                        <button
+                            onClick={() => props.setShowModal(false)}
+                            className="text-gray-700 hover:text-blue-500 transition-colors cursor-pointer"
+                        >Close</button>
+                    </div>
+                </div>
+            ) : null}
+        </>
+    );
+};
+
+export default LogoutModal;


### PR DESCRIPTION
構文木のデザインを変更してある程度見やすい形に
ログインするとアイコンを表示、アイコンを押すと下にログアウトボタンが出現、それを押すことでログアウトできるというように変更した。