### PR TITLE
構文木サイズ変更+フルスクリーンモード追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.0.0",
         "react-d3-tree": "^3.6.5",
         "react-dom": "^19.0.0",
+        "react-full-screen": "^1.1.1",
         "react-router-dom": "^7.2.0"
       },
       "devDependencies": {
@@ -2749,6 +2750,12 @@
         }
       }
     },
+    "node_modules/fscreen": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3612,6 +3619,21 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-full-screen": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-full-screen/-/react-full-screen-1.1.1.tgz",
+      "integrity": "sha512-xoEgkoTiN0dw9cjYYGViiMCBYbkS97BYb4bHPhQVWXj1UnOs8PZ1rPzpX+2HMhuvQV1jA5AF9GaRbO3fA5aZtg==",
+      "license": "MIT",
+      "dependencies": {
+        "fscreen": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-d3-tree": "^3.6.5",
     "react-dom": "^19.0.0",
+    "react-full-screen": "^1.1.1",
     "react-router-dom": "^7.2.0"
   },
   "devDependencies": {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -53,3 +53,8 @@
 .read-the-docs {
   color: #888;
 }
+
+.fullscreen {
+  height: 100vh;
+  background: #fff;
+}

--- a/frontend/src/components/ASTTree.tsx
+++ b/frontend/src/components/ASTTree.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import Tree from "react-d3-tree";
 import { ASTNode } from "../services/api";
+import { FullScreen, useFullScreenHandle } from "react-full-screen";
 
 interface TreeNode {
     name: string;
@@ -85,6 +86,8 @@ const ASTTree: React.FC<ASTTreeProps> = ({ node }) => {
     const [dfsOrder, setDfsOrder] = useState<number[]>([]);
     const treeContainer = useRef<HTMLDivElement>(null);
 
+    const handle = useFullScreenHandle();
+
     useEffect(() => {
         if (treeContainer.current) {
             const dimensions = treeContainer.current.getBoundingClientRect();
@@ -119,29 +122,34 @@ const ASTTree: React.FC<ASTTreeProps> = ({ node }) => {
 
     const containerStyles = {
         width: "100%",
-        height: "800px",
+        height: "100%",
         border: "1px solid #ccc",
         backgroundColor: "#ffffff",
     };
 
     return (
         <div id="treeWrapper" style={containerStyles} ref={treeContainer}>
-            <Tree
-                data={treeData}
-                translate={translate}
-                orientation="vertical"
-                pathFunc="elbow"
-                collapsible
-                transitionDuration={1250}
-                enableLegacyTransitions
-                renderCustomNodeElement={({ nodeDatum }) => (
-                    <CustomNodeElement
-                        nodeDatum={nodeDatum}
-                        highlighted={nodeDatum.attributes?.id === currentHighlightId}
+            <button className="relative top-2 left-[44%] border-2 border-black p-1 bg-white cursor-pointer text-gray-700 hover:text-blue-500 transition-colors" onClick={handle.enter}>
+                フルスクリーン
+            </button>
+            <FullScreen handle={handle}>
+                    <Tree
+                        data={treeData}
+                        translate={translate}
+                        orientation="vertical"
+                        pathFunc="elbow"
+                        collapsible
+                        transitionDuration={1250}
+                        enableLegacyTransitions
+                        renderCustomNodeElement={({ nodeDatum }) => (
+                            <CustomNodeElement
+                                nodeDatum={nodeDatum}
+                                highlighted={nodeDatum.attributes?.id === currentHighlightId}
+                            />
+                        )}
+                        zoomable
                     />
-                )}
-                zoomable
-            />
+            </FullScreen>
         </div>
     );
 };

--- a/frontend/src/pages/ASTPage.tsx
+++ b/frontend/src/pages/ASTPage.tsx
@@ -78,7 +78,7 @@ const ASTPage: React.FC = () => {
         <div className="relative">
             {!showSaveModal && (
                 <div className="container mx-auto p-6 pt-20">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div className="flex flex-col gap-6">
                         {/* コード入力フォーム */}
                         <div className="bg-white p-6 rounded-lg shadow">
                             <h2 className="text-2xl font-bold mb-4">コード入力</h2>


### PR DESCRIPTION
縦並びに変更して表示部分の横幅を増やし、かつより大きい画面で見れるフルスクリーンモードを新たに追加した(構文木表示右上のフルスクリーンボタンからフルスクリーンにできる) もし動かなかった場合はfrontのコンテナで「npm install react-full-screen」で動くはず

以下フルスクリーンイメージ画像

<img width="1440" alt="スクリーンショット 2025-02-24 11 58 08" src="https://github.com/user-attachments/assets/b0d57a21-ae29-431f-bc30-e6fb8ff34722" />