### PR TITLE
AWSリソースの変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode/
 
 .env
+.env.production
 *.env
 
 **/.terraform/*
@@ -19,3 +20,7 @@ override.tf.json
 .terraform.tfstate.lock.info
 .terraformrc
 terraform.rc
+
+terraform/deploy.sh
+terraform/deploy_api.sh
+terraform/deploy_web.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 > 抽象構文木（AST）の生成・可視化ツール  
-> [デモURL](http://ast-generator-alb-882047228.ap-northeast-1.elb.amazonaws.com/)
+> https://ast-generator.t2469.com/
 
 ![ast-generator](images/ast-generator.png)
 
@@ -21,7 +21,7 @@
 | **バックエンド**  | Go (Gin Framework)                                      |
 | **インフラ**    | Docker, Docker Compose                                  |
 | **IaC**     | Terraform                                               |
-| **クラウド環境**  | AWS (ECS [Fargate], ECR, RDS, VPC, ALB, NATインスタンス[EC2]) |
+| **クラウド環境**  | AWS (S3, CloudFront, ECS [Fargate], ALB, NATインスタンス[EC2], RDS) |
 
 ---
 

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -1,0 +1,69 @@
+resource "aws_acm_certificate" "api_cert" {
+  domain_name       = "${var.api_subdomain}.${var.root_domain}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route53_record" "api_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.api_cert.domain_validation_options :
+    dvo.domain_name => dvo
+  }
+
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  type            = each.value.resource_record_type
+  zone_id         = data.aws_route53_zone.primary.zone_id
+  records = [each.value.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "api_cert_validation" {
+  certificate_arn         = aws_acm_certificate.api_cert.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.api_cert_validation : record.fqdn
+  ]
+}
+
+resource "aws_acm_certificate" "frontend_cert" {
+  provider          = aws.us_east_1
+  domain_name       = "${var.frontend_subdomain}.${var.root_domain}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project = var.project_name
+  }
+}
+
+resource "aws_route53_record" "frontend_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.frontend_cert.domain_validation_options :
+    dvo.domain_name => dvo
+  }
+
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  type            = each.value.resource_record_type
+  zone_id         = data.aws_route53_zone.primary.zone_id
+  records = [each.value.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "frontend_cert_validation" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.frontend_cert.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.frontend_cert_validation : record.fqdn
+  ]
+}

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -2,75 +2,14 @@ resource "aws_lb" "app_alb" {
   name               = "${var.project_name}-alb"
   internal           = false
   load_balancer_type = "application"
-  subnets = [aws_subnet.public_a.id, aws_subnet.public_c.id]
   security_groups = [aws_security_group.alb_sg.id]
+  subnets = [aws_subnet.public_a.id, aws_subnet.public_c.id]
 
   tags = {
-    Name = "${var.project_name}-alb"
+    Name    = "${var.project_name}-alb"
+    Project = var.project_name
   }
 }
-
-resource "aws_lb_target_group" "backend_tg" {
-  name        = "${var.project_name}-backend-tg"
-  port        = 8080
-  protocol    = "HTTP"
-  vpc_id      = aws_vpc.main.id
-  target_type = "ip"
-
-  health_check {
-    path                = "/health"
-    interval            = 300
-    timeout             = 5
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-399"
-  }
-}
-
-resource "aws_lb_target_group" "frontend_tg" {
-  name        = "${var.project_name}-frontend-tg"
-  port        = 5173
-  protocol    = "HTTP"
-  vpc_id      = aws_vpc.main.id
-  target_type = "ip"
-
-  health_check {
-    path                = "/"
-    interval            = 300
-    timeout             = 5
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    matcher             = "200-399"
-  }
-}
-
-resource "aws_lb_listener" "http_listener" {
-  load_balancer_arn = aws_lb.app_alb.arn
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.frontend_tg.arn
-  }
-}
-
-resource "aws_lb_listener_rule" "backend_rule" {
-  listener_arn = aws_lb_listener.http_listener.arn
-  priority     = 10
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.backend_tg.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/parse", "/auth/*", "/source_codes*", "/health"]
-    }
-  }
-}
-
 
 resource "aws_security_group" "alb_sg" {
   name        = "${var.project_name}-alb-sg"
@@ -84,6 +23,13 @@ resource "aws_security_group" "alb_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port = 0
     to_port   = 0
@@ -92,6 +38,58 @@ resource "aws_security_group" "alb_sg" {
   }
 
   tags = {
-    Name = "${var.project_name}-alb-sg"
+    Name    = "${var.project_name}-alb-sg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_lb_target_group" "api_tg" {
+  name        = "${var.project_name}-api-tg"
+  port        = 8080
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.main.id
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name    = "${var.project_name}-api-tg"
+    Project = var.project_name
+  }
+}
+
+resource "aws_lb_listener" "api_listener" {
+  load_balancer_arn = aws_lb.app_alb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "api_https_listener" {
+  load_balancer_arn = aws_lb.app_alb.arn
+  port              = 443
+  protocol          = "HTTPS"
+
+  certificate_arn = aws_acm_certificate_validation.api_cert_validation.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api_tg.arn
   }
 }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,9 +1,4 @@
-resource "aws_cloudwatch_log_group" "ecs_backend_log_group" {
-  name              = "/ecs/ecs-backend-task"
-  retention_in_days = 7
-}
-
-resource "aws_cloudwatch_log_group" "ecs_frontend_log_group" {
-  name              = "/ecs/ecs-frontend-task"
+resource "aws_cloudwatch_log_group" "ecs_api_log_group" {
+  name              = "/ecs/${var.project_name}-api"
   retention_in_days = 7
 }

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,7 +1,12 @@
-resource "aws_ecr_repository" "backend" {
-  name = "backend-repo"
-}
+resource "aws_ecr_repository" "api_repo" {
+  name = "${var.project_name}-api"
 
-resource "aws_ecr_repository" "frontend" {
-  name = "frontend-repo"
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    Name    = "${var.project_name}-api"
+    Project = var.project_name
+  }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,7 +5,7 @@ output "vpc_id" {
 
 output "ecs_cluster_id" {
   description = "ID of the created ECS Cluster"
-  value       = aws_ecs_cluster.main.id
+  value       = aws_ecs_cluster.api_cluster.id
 }
 
 output "alb_dns_name" {
@@ -16,4 +16,9 @@ output "alb_dns_name" {
 output "rds_endpoint" {
   description = "Endpoint of the RDS instance"
   value       = aws_db_instance.db.address
+}
+
+output "cloudfront_domain_name" {
+  description = "Domain name of the CloudFront Distribution"
+  value       = aws_cloudfront_distribution.frontend_distribution.domain_name
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,3 +1,8 @@
 provider "aws" {
   region = var.aws_region
 }
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -1,14 +1,18 @@
-resource "aws_db_subnet_group" "main" {
-  name = "db-subnet-group"
-  subnet_ids = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name = "${var.project_name}-rds-subnet"
+  subnet_ids = [
+    aws_subnet.private_a.id,
+    aws_subnet.private_c.id
+  ]
 
   tags = {
-    Name = "${var.project_name}-db-subnet-group"
+    Name    = "${var.project_name}-rds-subnet"
+    Project = var.project_name
   }
 }
 
 resource "aws_security_group" "rds_sg" {
-  name        = "rds-sg"
+  name        = "${var.project_name}-rds-sg"
   description = "Security group for RDS instance"
   vpc_id      = aws_vpc.main.id
 
@@ -16,7 +20,7 @@ resource "aws_security_group" "rds_sg" {
     from_port = 3306
     to_port   = 3306
     protocol  = "tcp"
-    security_groups = [aws_security_group.ecs_service_sg.id]
+    security_groups = [aws_security_group.api_service_sg.id]
   }
 
   egress {
@@ -25,20 +29,30 @@ resource "aws_security_group" "rds_sg" {
     protocol  = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  tags = {
+    Name    = "${var.project_name}-rds-sg"
+    Project = var.project_name
+  }
 }
 
 resource "aws_db_instance" "db" {
-  identifier          = "db-instance"
-  engine              = "mysql"
-  engine_version      = "8.0"
-  instance_class      = "db.t3.micro"
-  allocated_storage   = 20
-  username            = var.db_username
-  password            = var.db_password
-  db_name             = var.db_name
-  publicly_accessible = false
+  identifier           = "${var.project_name}-mysql"
+  engine               = "mysql"
+  engine_version       = "8.0"
+  instance_class       = "db.t3.micro"
+  allocated_storage    = 20
+  username             = var.db_username
+  password             = var.db_password
+  db_name              = var.db_name
+  publicly_accessible  = false
   vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+
   skip_final_snapshot = true
 
-  db_subnet_group_name = aws_db_subnet_group.main.name
+  tags = {
+    Name    = "${var.project_name}-postgres"
+    Project = var.project_name
+  }
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,11 +1,28 @@
-# resource "aws_route53_record" "app_record" {
-#   zone_id = var.hosted_zone_id
-#   name    = var.domain_name
-#   type    = "A"
-#
-#   alias {
-#     name                   = aws_lb.app_alb.dns_name
-#     zone_id                = aws_lb.app_alb.zone_id
-#     evaluate_target_health = true
-#   }
-# }
+data "aws_route53_zone" "primary" {
+  name         = var.root_domain
+  private_zone = false
+}
+
+resource "aws_route53_record" "attendance_frontend" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "${var.frontend_subdomain}.${var.root_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.frontend_distribution.domain_name
+    zone_id                = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "api_attendance" {
+  zone_id = data.aws_route53_zone.primary.zone_id
+  name    = "${var.api_subdomain}.${var.root_domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.app_alb.dns_name
+    zone_id                = aws_lb.app_alb.zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terraform/s3_cloudfront.tf
+++ b/terraform/s3_cloudfront.tf
@@ -1,0 +1,110 @@
+resource "aws_s3_bucket" "frontend_bucket" {
+  bucket = "${var.project_name}-frontend"
+
+  tags = {
+    Name    = "${var.project_name}-frontend"
+    Project = var.project_name
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "frontend_bucket_website" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "error.html"
+  }
+}
+
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "OAI for ${var.project_name} frontend"
+}
+
+resource "aws_s3_bucket_policy" "frontend_bucket_policy" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "GrantCloudFrontAccess",
+        Effect = "Allow",
+        Principal = {
+          AWS = aws_cloudfront_origin_access_identity.oai.iam_arn
+        },
+        Action   = "s3:GetObject",
+        Resource = "${aws_s3_bucket.frontend_bucket.arn}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudfront_distribution" "frontend_distribution" {
+  aliases = ["${var.frontend_subdomain}.${var.root_domain}"]
+
+  origin {
+    domain_name = aws_s3_bucket.frontend_bucket.bucket_regional_domain_name
+    origin_id   = "S3-${aws_s3_bucket.frontend_bucket.id}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.project_name} frontend distribution"
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "S3-${aws_s3_bucket.frontend_bucket.id}"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  custom_error_response {
+    error_code            = 403
+    response_page_path    = "/index.html"
+    response_code         = 200
+    error_caching_min_ttl = 0
+  }
+
+  custom_error_response {
+    error_code            = 404
+    response_page_path    = "/index.html"
+    response_code         = 200
+    error_caching_min_ttl = 0
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.frontend_cert_validation.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2019"
+  }
+
+  tags = {
+    Name    = "${var.project_name}-frontend"
+    Project = var.project_name
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -104,23 +104,25 @@ variable "vite_api_url" {
   description = "Frontend URL used by the backend service"
 }
 
-variable "backend_image_tag" {
+variable "root_domain" {
+  description = "The root domain in Route53"
   type        = string
-  description = "Docker image tag for versioning the backend image"
+  default     = "t2469.com"
 }
 
-variable "frontend_image_tag" {
+variable "frontend_subdomain" {
+  description = "Subdomain for the frontend"
   type        = string
-  description = "Docker image tag for versioning the frontend image"
+  default     = "ast-generator"
 }
 
+variable "api_subdomain" {
+  description = "Subdomain for API ALB"
+  type        = string
+  default     = "api.ast-generator"
+}
 
-# variable "hosted_zone_id" {
-#   description = "Route53 hosted zone ID"
-#   type        = string
-# }
-#
-# variable "domain_name" {
-#   description = "Domain name for the Route53 record"
-#   type        = string
-# }
+variable "image_tag" {
+  description = "Docker image tag for versioning the api image"
+  type        = string
+}


### PR DESCRIPTION
## 変更内容
- フロントエンドを ECS Fargate から S3 + CloudFront へ変更
- route 53 を使用し、ALB のドメイン名ではなく独自ドメイン（t2469.com）を使用。このドメインは他のアプリケーションでも使用しているため、サブドメインを利用 (https://ast-generator.t2469.com/)
- ACMを使用して、ALB に証明書を発行
